### PR TITLE
Fix name parsing in Table constructor

### DIFF
--- a/src/table.coffee
+++ b/src/table.coffee
@@ -7,7 +7,7 @@ class Table
 			path = name.match /^(\[?([^\]]*)\]?\.)?(\[?([^\]]*)\]?\.)?\[?([^\]]*)\]?$/
 			@name = path[5]
 			@schema = if path[4]? then path[4] else if path[2] then path[2] else null
-			@database = path[2] ? null
+			@database = if path[4]? then path[2] ? null else null
 			@path = "#{if @database then "[#{@database}]." else ""}#{if @schema then "[#{@schema}]." else ""}[#{@name}]"
 			@temporary = @name.charAt(0) is '#'
 		


### PR DESCRIPTION
A table name of the form *schema*.*table* is parsed as *@database* = *schema* and *@path* = *schema*.*schema*.*table*.  This is wrong, as *@database* should be null and *@path* should be *schema*.*table*.

* Note: I do not know CoffeeScript. I tested the changes by editing the table.js file, and it worked.