### PR TITLE
Release connection to pool on query error

### DIFF
--- a/src/msnodesql.coffee
+++ b/src/msnodesql.coffee
@@ -309,6 +309,8 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 							@_log " duration: #{elapsed}ms"
 							@_log "---------- completed ----------"
 						
+						@_release connection
+
 						callback? e
 					
 					req.once 'done', =>


### PR DESCRIPTION
In case of an error when executing sql query, the connection isnt returned back to the pool.
This changes fixes the issue.