### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,7 @@
 		"type": "git",
 		"url": "https://github.com/patriksimek/node-mssql"
 	},
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "http://opensource.org/licenses/mit-license.php"
-		}
-	],
+	"license": "MIT",
 	"dependencies": {
 		"tedious": "^1.11.0",
 		"generic-pool": "^2.2.0",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/