### PR TITLE
Update tedious version to 1.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-		"tedious": "1.11.4",
+		"tedious": "~1.12.2",
 		"generic-pool": "^2.2.0",
 		"promise": "^7.0.1"
 	},


### PR DESCRIPTION
Have verified that as of 1.12.2, NTLM auth is working again.