### PR TITLE
Update bulk: resolve promise with rowCount

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -1054,9 +1054,9 @@ class Request extends EventEmitter
 			return @_bulk table, callback
 		
 		new module.exports.Promise (resolve, reject) =>
-			@_bulk table, (err) ->
+			@_bulk table, (err, rowCount) ->
 				if err then return reject err
-				resolve()
+				resolve rowCount
 
 	_bulk: (table, callback) ->
 		unless @connection


### PR DESCRIPTION
When using the bulk method without a callback, the returned promise
should resolve with the row count to match the normal callback
behavior.