### PR TITLE
Make sure that tedious Request calls callback function on errors.

### DIFF
--- a/src/tedious.coffee
+++ b/src/tedious.coffee
@@ -342,6 +342,7 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 			started = Date.now()
 			errors = []
 			errorHandlers = {}
+			hasReturned = false
 			handleError = (doReturn, connection, info) =>
 				err = new Error info.message
 				err.info = info
@@ -720,6 +721,7 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 			errors = []
 			isJSONRecordset = false
 			jsonBuffer = null
+			hasReturned = false
 			errorHandlers = {}
 			handleError = (doReturn, connection, info) =>
 				err = new Error info.message

--- a/src/tedious.coffee
+++ b/src/tedious.coffee
@@ -341,14 +341,23 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 
 			started = Date.now()
 			errors = []
-			handleError = (info) =>
+			errorHandlers = {}
+			handleError = (doReturn, connection, info) =>
 				err = new Error info.message
 				err.info = info
 				e = RequestError err, 'EREQUEST'
 
 				if @stream
 					@emit 'error', e
-				
+				else
+					if (doReturn && !hasReturned)
+						if connection?
+							for event, handler of errorHandlers
+								connection.removeListener event, handler
+							@_release connection
+						hasReturned = true
+						callback?(e)
+
 				# we must collect errors even in stream mode
 				errors.push e
 
@@ -366,7 +375,11 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 						connection.cancel()
 					
 					# attach handler to handle multiple error messages
-					connection.on 'errorMessage', handleError
+					errorHandlers['errorMessage'] = handleError.bind(undefined, false, connection)
+					errorHandlers['error']        = handleError.bind(undefined, true, connection)
+					connection.on 'errorMessage', errorHandlers['errorMessage']
+					connection.on 'error',        errorHandlers['error']
+
 					
 					done = (err, rowCount) =>
 						# to make sure we handle no-sql errors as well
@@ -394,14 +407,17 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 							error = errors.pop()
 							error.precedingErrors = errors
 						
-						connection.removeListener 'errorMessage', handleError
-						@_release connection
+						if (!hasReturned)
+							for event, handler of errorHandlers
+								connection.removeListener event, handler
+							@_release connection
+							hasReturned = true
 						
-						if @stream
-							callback null, null
+							if @stream
+								callback null, null
 						
-						else
-							callback? error, rowCount
+							else
+								callback? error, rowCount
 					
 					bulk = connection.newBulkLoad table.path, done
 
@@ -443,14 +459,24 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 			batchHasOutput = false
 			isJSONRecordset = false
 			jsonBuffer = null
-			handleError = (info) =>
+			hasReturned = false
+			errorHandlers = {}
+			handleError = (doReturn, connection, info) =>
 				err = new Error info.message
 				err.info = info
 				e = RequestError err, 'EREQUEST'
 				
 				if @stream
 					@emit 'error', e
-				
+				else
+					if (doReturn && !hasReturned)
+						if connection?
+							for event, handler of errorHandlers
+								connection.removeListener event, handler
+							@_release connection
+						hasReturned = true
+						callback?(e)
+
 				# we must collect errors even in stream mode
 				errors.push e
 			
@@ -468,7 +494,10 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 						connection.cancel()
 					
 					# attach handler to handle multiple error messages
-					connection.on 'errorMessage', handleError
+					errorHandlers['errorMessage'] = handleError.bind(undefined, false, connection)
+					errorHandlers['error']        = handleError.bind(undefined, true, connection)
+					connection.on 'errorMessage', errorHandlers['errorMessage']
+					connection.on 'error',        errorHandlers['error']
 					
 					req = new tds.Request command, (err) =>
 						# to make sure we handle no-sql errors as well
@@ -508,14 +537,17 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 							error = errors.pop()
 							error.precedingErrors = errors
 						
-						connection.removeListener 'errorMessage', handleError
-						@_release connection
-						
-						if @stream
-							callback null, null
-						
-						else
-							callback? error, if @multiple then recordsets else recordsets[0]
+						if (!hasReturned)
+							for event, handler of errorHandlers
+								connection.removeListener event, handler
+							@_release connection
+							hasReturned = true
+
+							if @stream
+								callback null, null
+							
+							else
+								callback? error, if @multiple then recordsets else recordsets[0]
 					
 					req.on 'columnMetadata', (metadata) =>
 						columns = createColumns metadata
@@ -688,14 +720,23 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 			errors = []
 			isJSONRecordset = false
 			jsonBuffer = null
-			handleError = (info) =>
+			errorHandlers = {}
+			handleError = (doReturn, connection, info) =>
 				err = new Error info.message
 				err.info = info
 				e = RequestError err, 'EREQUEST'
 				
 				if @stream
 					@emit 'error', e
-				
+				else
+					if (doReturn && !hasReturned)
+						if connection?
+							for event, handler of errorHandlers
+								connection.removeListener event, handler
+							@_release connection
+						hasReturned = true
+						callback?(e)
+					
 				# we must collect errors even in stream mode
 				errors.push e
 
@@ -713,7 +754,11 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 						connection.cancel()
 					
 					# attach handler to handle multiple error messages
-					connection.on 'errorMessage', handleError
+					errorHandlers['errorMessage'] = handleError.bind(undefined, false, connection)
+					errorHandlers['error']        = handleError.bind(undefined, true, connection)
+					connection.on 'errorMessage', errorHandlers['errorMessage']
+					connection.on 'error',        errorHandlers['error']
+
 					
 					req = new tds.Request procedure, (err) =>
 						# to make sure we handle no-sql errors as well
@@ -740,15 +785,18 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 							error = errors.pop()
 							error.precedingErrors = errors
 						
-						connection.removeListener 'errorMessage', handleError
-						@_release connection
-						
-						if @stream
-							callback null, null, returnValue
-						
-						else
-							recordsets.returnValue = returnValue
-							callback? error, recordsets, returnValue
+						if (!hasReturned)
+							for event, handler of errorHandlers
+								connection.removeListener event, handler
+							@_release connection
+
+							hasReturned = true
+
+							if @stream
+								callback null, null, returnValue
+							else
+								recordsets.returnValue = returnValue
+								callback? error, recordsets, returnValue
 					
 					req.on 'columnMetadata', (metadata) =>
 						columns = createColumns metadata


### PR DESCRIPTION
If a query fails because of a connection error, the tedious connection will emit an "error" event.

But in node-mssql, the Tedious Request class does not listen for this event - only for the "errorMessage" event, which is emitted on e.g. syntax errors.

So Tedious Request's error handler should listen to both events. With one difference: Tedious' own errorMessage handler actively creates a request error and returns it to node-mssql's Tedious Request.

But everwhere the "error" event is emitted from tedious (e.g. in SocketError), no request error is created.

As a result, the Tedious Request never calls its callback on connection errors.

This change makes sure that the callback is called with a proper error object, as would be expected.
There is also logic to ensure that the callback is only called once.
