### PR TITLE
Text and NText parameters

### DIFF
--- a/src/datatypes.coffee
+++ b/src/datatypes.coffee
@@ -45,9 +45,9 @@ for key, value of TYPES
 
 module.exports.declare = (type, options) ->
 	switch type
-		when TYPES.VarChar, TYPES.NVarChar, TYPES.VarBinary
+		when TYPES.VarChar, TYPES.VarBinary, TYPES.Text
 			return "#{type.declaration} (#{if options.length > 8000 then 'MAX' else (options.length ? 'MAX')})"
-		when TYPES.NVarChar
+		when TYPES.NVarChar, TYPES.NText
 			return "#{type.declaration} (#{if options.length > 4000 then 'MAX' else (options.length ? 'MAX')})"
 		when TYPES.Char, TYPES.NChar, TYPES.Binary
 			return "#{type.declaration} (#{options.length ? 1})"

--- a/src/datatypes.coffee
+++ b/src/datatypes.coffee
@@ -45,10 +45,14 @@ for key, value of TYPES
 
 module.exports.declare = (type, options) ->
 	switch type
-		when TYPES.VarChar, TYPES.VarBinary, TYPES.Text
+		when TYPES.VarChar, TYPES.VarBinary
 			return "#{type.declaration} (#{if options.length > 8000 then 'MAX' else (options.length ? 'MAX')})"
-		when TYPES.NVarChar, TYPES.NText
+		when TYPES.NVarChar
 			return "#{type.declaration} (#{if options.length > 4000 then 'MAX' else (options.length ? 'MAX')})"
+		when TYPES.NText
+			return "nvarchar (MAX)";
+		when TYPES.Text
+			return "varchar (MAX)";
 		when TYPES.Char, TYPES.NChar, TYPES.Binary
 			return "#{type.declaration} (#{options.length ? 1})"
 		when TYPES.Decimal, TYPES.Numeric


### PR DESCRIPTION
Issue #304

Creating parametrized query (ie for update) doesn't work with fields
with ntext or text type. Original error message:
> The text, ntext, and image data types are invalid for local variables.

Remove duplicate case key TYPES.NVarChar