### PR TITLE
Accept config.driver as a module for browserify/webpack compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+*****
+
+This is a fork of [https://github.com/patriksimek/node-mssql]() with added
+support for [dynamic driver
+option](https://github.com/jholster/node-mssql/commit/f56617ef38d5c3ed99c5647d1d8163859fda85a3)
+for browserify compatibility. This fork will be deleted if the patch is
+accepted in the original project.
+
+Installable as `npm install mssql2`.
+
+*****
+
 # node-mssql
 
 Microsoft SQL Server client for Node.js

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
 	"author": {
-		"name": "Patrik Simek",
-		"url": "https://patriksimek.cz"
+		"name": "Jaakko Holster (originally Patrik Simek)"
 	},
-	"name": "mssql",
-	"description": "Microsoft SQL Server client for Node.js.",
+	"name": "mssql2",
+	"description": "Microsoft SQL Server client for Node.js (fork)",
 	"keywords": [
 		"database",
 		"mssql",
@@ -21,11 +20,11 @@
 		"azure",
 		"node-mssql"
 	],
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"main": "index.js",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/patriksimek/node-mssql"
+		"url": "https://github.com/jholster/node-mssql"
 	},
 	"license": "MIT",
 	"dependencies": {

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -134,8 +134,8 @@ class Connection extends EventEmitter
 		if @config.driver in DRIVERS
 			@driver = @initializeDriver require("./#{@config.driver}")
 			
-			# fix the driver by default
-			if module.exports.fix then @driver.fix()
+		else if typeof @config.driver is 'function'
+			@driver = @initializeDriver @config.driver
 
 		else
 			err = new ConnectionError "Unknown driver #{@config.driver}!", 'EDRIVER'
@@ -144,6 +144,9 @@ class Connection extends EventEmitter
 				return callback err
 			else
 				throw err
+		
+		# fix the driver by default
+		if module.exports.fix then @driver.fix()
 
 		if callback then @connect callback
 	


### PR DESCRIPTION
The node-mssql tries to resolve driver module path at runtime (from 'driver' configuration option), making the project incompatible with popular bundler systems (browserify, webpack, etc) which can only resolve static module paths. This patch makes possible to pass the driver module directly in 'driver' option (instead of string), eliminating the need for runtime module path resolving. An example:

mssql = require('mssql')
mssql.connect({ driver: require('mssql/lib/tedious') })

Fixes https://github.com/patriksimek/node-mssql/issues/318
