### PR TITLE
fix: support for utf8 characters in xml

### DIFF
--- a/src/tedious.coffee
+++ b/src/tedious.coffee
@@ -46,7 +46,7 @@ getTediousType = (type) ->
 		when TYPES.DateTimeOffset then return tds.TYPES.DateTimeOffsetN
 		when TYPES.SmallDateTime then return tds.TYPES.SmallDateTime
 		when TYPES.UniqueIdentifier then return tds.TYPES.UniqueIdentifierN
-		when TYPES.Xml then return tds.TYPES.VarChar
+		when TYPES.Xml then return tds.TYPES.NVarChar
 		when TYPES.Char then return tds.TYPES.Char
 		when TYPES.NChar then return tds.TYPES.NChar
 		when TYPES.NText then return tds.TYPES.NVarChar


### PR DESCRIPTION
At the moment native XML is not supporting cyrillic and chinese symbols.
This is caused by convertion of xml to varchar in file terious.coffee. 
In order to fix this, varchar should be changed to nvarchar.