### PR TITLE
Fixed invalid connection ref in handler

### DIFF
--- a/lib/tedious.js
+++ b/lib/tedious.js
@@ -960,7 +960,7 @@ class Request extends base.Request {
 					}
 					
 					if (isChunkedRecordset) {
-						if (columns[JSON_COLUMN_ID] && this.connection.config.parseJSON === true) {
+						if (columns[JSON_COLUMN_ID] && connection.config.parseJSON === true) {
 							try {
 								row = JSON.parse(chunksBuffer.join(''));
 							} catch (ex) {


### PR DESCRIPTION
When checking for the connection.config.parseJSON flag the coffeescript incorrectly adds "this." to the front even though the connection is the ambient scope variable "connection" -- should also be corrected in tedious.coffee to remove the '@'

Found this when returning JSON column